### PR TITLE
bumped the embedded-graphics-core version and align crate verision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package] 
 name = "is31fl3741"
-version = "0.4.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Liz Frost", "Daniel Schaefer"]
 categories = ["embedded", "no-std"]
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 embedded-hal = "1.0"
-embedded-graphics-core = { optional = true, version = "0.4.0" }
+embedded-graphics-core = { optional = true, version = "0.4.1" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Driver for [Lumissil Microsystem's IS31FL3741 integrated circuit](https://www.lu
 To install this driver in your project add the following line to your `Cargo.toml`'s `dependencies` table:
 
 ```toml
-is31fl3741 = "0.4.0"
+is31fl3741 = "0.5.1"
 ```
 
 By default this version will only contain the core driver.
@@ -27,8 +27,8 @@ To use a preconfigured device ([Framework LED Matrix](https://frame.work/tw/en/p
 you would need to change this line to include that device:
 
 ```toml
-is31fl3741 = { version = "0.4.0", features = ["framework_ledmatrix"] }
-is31fl3741 = { version = "0.4.0", features = ["adafruit_rgb_13x9"] }
+is31fl3741 = { version = "0.5.1", features = ["framework_ledmatrix"] }
+is31fl3741 = { version = "0.5.1", features = ["adafruit_rgb_13x9"] }
 ```
 
 ## Graphics


### PR DESCRIPTION
This is change bumps the version of `embedded-graphics-core` and aligns the crate version with the version stated in the release and crates.io.